### PR TITLE
remove CNAME for migration

### DIFF
--- a/app/CNAME
+++ b/app/CNAME
@@ -1,1 +1,1 @@
-rcrcsims.org
+


### PR DESCRIPTION
Left the CNAME file intact but removed the content. Not familiar with comment syntax on CNAMEs, otherwise would have just commented it out. 